### PR TITLE
Revert "Enclose author & email in quotes"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,8 @@
 name = dls-python3-skeleton
 description = One line description of your module
 url = https://github.com/dls-controls/dls-python3-skeleton
-# author & author_email enclosed in quotes to allow for apostrophes
-author = "Firstname Lastname"
-author_email = "email@address.com"
+author = Firstname Lastname
+author_email = email@address.com
 license = Apache License 2.0
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Reverts dls-controls/dls-python3-skeleton#23

Turns out:
- The METADATA file found in the wheel's dist-info should be of the same format as PKG-INFO in sdists ([PEP427](https://peps.python.org/pep-0427/#the-dist-info-directory))
- The Author-email field in PKG-INFO should conform to the RFC822 standard ([PEP314](https://peps.python.org/pep-0314/#author-email))
- [RFC822](https://datatracker.ietf.org/doc/html/rfc822.html#section-6.1) doesn't specify anything regarding ' (RFC822)

So actually, the use of ' in package metadata is left undefined
Similarly, .cfg parsers may optionally support escaping of ' with \', but this is not mandated

`configparser.ConfigParser` doesn't support escaping or quoting, so the workaround is:

```ini
author = First O'Last
author_email = first.o'last@example.com
license = Apache License 2.0
```

This breaks syntax highlighters (as you can see above), but works on pypi.org which is the only consumer of this