### PR TITLE
Add check that skeleton is not already adopted

### DIFF
--- a/tests/test_dls_python3_skeleton.py
+++ b/tests/test_dls_python3_skeleton.py
@@ -125,3 +125,23 @@ Instructions on how to develop this module are in CONTRIBUTING.rst
     assert output.strip("\n") == f"{MERGE_BRANCH} deleted from existing repo"
     branches = __main__.list_branches(module)
     assert MERGE_BRANCH not in branches
+
+
+def test_existing_module_already_adopted(tmp_path: Path):
+    module = tmp_path / "scanspec"
+    __main__.git(
+        "clone",
+        "--branch",
+        "0.5.4",  # dls-python3-skeleton was adopted in this release
+        "https://github.com/dls-controls/scanspec",
+        str(module),
+    )
+    with pytest.raises(Exception) as excinfo:
+        check_output(
+            sys.executable,
+            "-m",
+            "dls_python3_skeleton",
+            "existing",
+            str(module),
+        )
+    assert "already adopted skeleton" in str(excinfo.value)

--- a/tests/test_dls_python3_skeleton.py
+++ b/tests/test_dls_python3_skeleton.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 from configparser import ConfigParser
+from os import makedirs
 from pathlib import Path
 
 import pytest
@@ -66,6 +67,25 @@ def test_new_module(tmp_path: Path):
     assert "Please change ./docs/reference/api.rst" in out
     assert "Please delete ./docs/how-to/accomplish-a-task.rst" in out
     assert "Please delete ./docs/explanations/why-is-something-so.rst" in out
+
+
+def test_new_module_existing_dir(tmp_path: Path):
+    module = tmp_path / "my-module"
+    makedirs(module / "existing_dir")
+
+    with pytest.raises(Exception) as excinfo:
+        check_output(
+            sys.executable,
+            "-m",
+            "dls_python3_skeleton",
+            "new",
+            "--org=myorg",
+            "--package=my_module",
+            "--full-name=Firstname Lastname",
+            "--email=me@myaddress.com",
+            str(module),
+        )
+    assert "to not exist, or be an empty dir" in str(excinfo.value)
 
 
 def test_existing_module(tmp_path: Path):


### PR DESCRIPTION
Todo
- The test should clone a tag once a release of scanspec is made with skeleton merged

Questions
- Is it OK to hard-code the root commit or should it be dynamic?
- Is this the correct way to test for a subprocess failing?